### PR TITLE
Add configurable sample display limits

### DIFF
--- a/Software/LogicAnalyzer/LogicAnalyzer/Classes/GeneralSettings.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Classes/GeneralSettings.cs
@@ -1,0 +1,8 @@
+namespace LogicAnalyzer.Classes
+{
+    public class GeneralSettings
+    {
+        public int MinSamples { get; set; } = 10;
+        public int MaxSamples { get; set; } = 10000;
+    }
+}

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml
@@ -1,0 +1,22 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        x:Class="LogicAnalyzer.Dialogs.GeneralSettingsDialog"
+        Background="#383838" Title="Settings"
+        Classes="tool_window" Icon="/Assets/Ico40.ico"
+        Width="300" Height="180" CanResize="False" WindowStartupLocation="CenterOwner">
+  <Panel>
+    <Grid ColumnDefinitions="140,*" RowDefinitions="*,*,Auto" Margin="10,15,10,15">
+      <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Margin="5,0,0,0">Min samples:</TextBlock>
+      <NumericUpDown Grid.Column="1" Grid.Row="0" Height="32" Minimum="1" Maximum="1000000" Name="nudMin" />
+      <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Center" Margin="5,0,0,0">Max samples:</TextBlock>
+      <NumericUpDown Grid.Column="1" Grid.Row="1" Height="32" Minimum="1" Maximum="1000000" Name="nudMax" />
+      <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Grid.Column="1" Grid.Row="2" HorizontalAlignment="Right">
+        <Button Name="btnAccept">Accept</Button>
+        <Button Name="btnCancel" Margin="10,0,0,0">Cancel</Button>
+      </StackPanel>
+    </Grid>
+  </Panel>
+</Window>

--- a/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
+++ b/Software/LogicAnalyzer/LogicAnalyzer/Dialogs/GeneralSettingsDialog.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using LogicAnalyzer.Extensions;
+using System;
+
+namespace LogicAnalyzer.Dialogs
+{
+    public partial class GeneralSettingsDialog : Window
+    {
+        public int MinSamples { get; set; }
+        public int MaxSamples { get; set; }
+
+        public GeneralSettingsDialog()
+        {
+            InitializeComponent();
+            btnAccept.Click += BtnAccept_Click;
+            btnCancel.Click += BtnCancel_Click;
+        }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            this.FixStartupPosition();
+            nudMin.Value = MinSamples;
+            nudMax.Value = MaxSamples;
+        }
+
+        private void BtnCancel_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            Close(false);
+        }
+
+        private async void BtnAccept_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            if (nudMax.Value < nudMin.Value)
+            {
+                await this.ShowError("Invalid settings", "Max samples must be greater than Min samples.");
+                return;
+            }
+            MinSamples = (int)nudMin.Value;
+            MaxSamples = (int)nudMax.Value;
+            Close(true);
+        }
+    }
+}

--- a/Software/LogicAnalyzer/LogicAnalyzer/LogicAnalyzer.csproj
+++ b/Software/LogicAnalyzer/LogicAnalyzer/LogicAnalyzer.csproj
@@ -52,6 +52,9 @@
     <Compile Update="Dialogs\SelectedRegionDialog.axaml.cs">
       <DependentUpon>SelectedRegionDialog.axaml</DependentUpon>
     </Compile>
+    <Compile Update="Dialogs\GeneralSettingsDialog.axaml.cs">
+      <DependentUpon>GeneralSettingsDialog.axaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />

--- a/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
+++ b/Software/LogicAnalyzer/LogicAnalyzer/MainWindow.axaml
@@ -17,7 +17,8 @@
           <Separator/>
           <MenuItem Header="_Exit" Name="mnuExit"/>
         </MenuItem>
-      <MenuItem Header="Network settings" IsEnabled="False" Name="mnuSettings">
+      <MenuItem Header="_Settings" Name="mnuSettings">
+        <MenuItem Header="General..." Name="mnuGeneralSettings"></MenuItem>
         <MenuItem Header="Update network settings" Name="mnuNetSettings"></MenuItem>
       </MenuItem>
       <MenuItem Header="Profiles" Name="mnuProfiles" IsEnabled="False">


### PR DESCRIPTION
## Summary
- add settings dialog to adjust min and max samples displayed
- store sample limit preferences in new `GeneralSettings` file and load at startup
- expose new Settings menu with network and general options

## Testing
- `dotnet build LogicAnalyzer.sln`


------
https://chatgpt.com/codex/tasks/task_e_68a0b018e8488321b7e2db3e1dc92d12